### PR TITLE
Avoid leaking a response body without being closed on error

### DIFF
--- a/gofss.go
+++ b/gofss.go
@@ -33,12 +33,12 @@ func (c *defaultClient) GeneratePDF(html string) ([]byte, error) {
     if err != nil {
         return nil, fmt.Errorf("could not generate pdf: %w", err)
     }
+    
+    defer closeQuietly(resp.Body)    
 
     if resp.StatusCode != http.StatusOK {
         return nil, fmt.Errorf("invalid pdf service response code: %d", resp.StatusCode)
     }
-
-    defer closeQuietly(resp.Body)
 
     jsonResp := msg{}
     err = json.NewDecoder(resp.Body).Decode(&jsonResp)


### PR DESCRIPTION
Hola!

This is a quick and simple suggestion, but I noticed you're closing the request body **after** checking the status code, so any request successfully done whose status code isn't 200 will leak a body.

From the Go documentation:

> If the returned error is nil, the Response will contain a non-nil Body which the user is expected to close. [#](https://golang.org/pkg/net/http/#Client.Do)

You also shouldn't need to validate if `c` is `nil` in `closeQuietly`. There's a guarantee from the standard library that if the error isn't `nil`, then there's always a `body` that's not `nil`.

